### PR TITLE
🐛Fix: remove duplicate function ft_strjoin_range in ft_strdup_range.c

### DIFF
--- a/libft/ft_strdup_range.c
+++ b/libft/ft_strdup_range.c
@@ -1,30 +1,5 @@
 #include "libft.h"
 
-char	*ft_strjoin_range(char const *s1, char const *s2, int start, int end)
-{
-	char	*dst;
-	char	*temp;
-	int		n;
-	int		i;
-
-	if (s1 == NULL || s2 == NULL)
-		return (NULL);
-	n = ft_strlen(s1) + ft_strlen(s2) + 1;
-	dst = (char *)malloc(n * sizeof(char));
-	if (dst == NULL)
-		return (NULL);
-	temp = dst;
-	while (*s1)
-		*temp++ = *s1++;
-	i = start;
-	while (s2[i] && i < end)
-		*temp++ = s2[i++];
-	*temp = 0;
-	return (dst);
-}
-
-#include "libft.h"
-
 char	*ft_strdup_range(const char *s1, int start, int end)
 {
 	int		size;


### PR DESCRIPTION
## 작업 이유
ft_strdup_range.c 불필요한 함수 제거
## 작업 사항

## 기타
